### PR TITLE
Solve timing problems

### DIFF
--- a/src/ar_kernel.cpp
+++ b/src/ar_kernel.cpp
@@ -507,7 +507,7 @@ void ar_kernel_scheduler()
         uint32_t delay = 0;
         if (g_ar.nextWakeup && g_ar.nextWakeup > g_ar.tickCount)
         {
-            delay = (g_ar.nextWakeup - g_ar.tickCount) * 10000;
+            delay = (g_ar.nextWakeup - g_ar.tickCount) * kSchedulerQuanta_ms * 1000;
         }
         bool enable = (g_ar.nextWakeup != 0);
         ar_port_set_timer_delay(enable, delay);
@@ -589,7 +589,7 @@ uint32_t ar_get_system_load(void)
 uint32_t ar_get_tick_count(void)
 {
 #if AR_ENABLE_TICKLESS_IDLE
-    uint32_t elapsed_ticks = ar_port_get_timer_elapsed_us() / 10000;
+    uint32_t elapsed_ticks = ar_port_get_timer_elapsed_us() / (kSchedulerQuanta_ms * 1000);
     return g_ar.tickCount + elapsed_ticks;
 #else
     return g_ar.tickCount;

--- a/src/cortex_m/ar_port.cpp
+++ b/src/cortex_m/ar_port.cpp
@@ -127,7 +127,7 @@ void ar_port_set_timer_delay(bool enable, uint32_t delay_us)
 
         // Calculate SysTick reload value. If the desired delay overflows the SysTick counter,
         // we just use the max delay (24 bits for SysTick).
-        uint32_t ticks = SystemCoreClock / 1000000 * delay_us; // TODO: need - 1 ?
+        uint32_t ticks = SystemCoreClock / 1000000 * delay_us - 1;
         if (ticks > SysTick_LOAD_RELOAD_Msk)
         {
             ticks = SysTick_LOAD_RELOAD_Msk;


### PR DESCRIPTION
Commit messages describe all changes.
1 ms tickless mode is working. What is the reason for kSchedulerQuanta_ms = 10 instead of 1?