### PR TITLE
minor fixes to solve some compiler warnings

### DIFF
--- a/include/argon/ar_kernel.h
+++ b/include/argon/ar_kernel.h
@@ -1187,7 +1187,7 @@ uint32_t ar_get_millisecond_count(void);
  * @brief Get a microsecond timestamp.
  * @return Elapsed time in microseconds since the system was started.
  */
-uint64_t ar_get_microseconds();
+uint64_t ar_get_microseconds(void);
 
 /*!
  * @brief Get the number of milliseconds per tick.

--- a/src/cortex_m/ar_port.h
+++ b/src/cortex_m/ar_port.h
@@ -127,7 +127,7 @@ static inline bool ar_port_get_irq_state(void)
     return __get_IPSR() != 0;
 }
 
-#if __cplusplus
+#if defined(__cplusplus)
 extern "C" inline uint32_t ar_get_milliseconds_per_tick();
 #else
 static inline uint32_t ar_get_milliseconds_per_tick(void);

--- a/src/cortex_m/ar_port.h
+++ b/src/cortex_m/ar_port.h
@@ -111,7 +111,7 @@ static inline void _halt()
 
 #if DEBUG
 //! @brief Make the PendSV exception pending.
-void ar_port_service_call();
+void ar_port_service_call(void);
 #else // DEBUG
 static inline void ar_port_service_call()
 {
@@ -122,7 +122,7 @@ static inline void ar_port_service_call()
 #endif // DEBUG
 
 //! @brief Returns true if in IRQ state.
-static inline bool ar_port_get_irq_state()
+static inline bool ar_port_get_irq_state(void)
 {
     return __get_IPSR() != 0;
 }


### PR DESCRIPTION
0865622 fixes warnings on -Wstrict-prototypes
cfbe000  fixes warnings on -Wundef

There is one more warning:
```
./argon-rtos/include/argon/ar_kernel.h:54:26: warning: ISO C restricts enumerator values to range of 'int' [-Wpedantic]
     kArInfiniteTimeout = 0xffffffffUL   //!< Pass this value to wait forever to acquire a resource.
```

`static const uint32_t  kArInfiniteTimeout = 0xffffffffUL;` would solve this warning, do/don't? (same would apply to `kArNoTimeout` for consistency